### PR TITLE
fix: remove `paperclip-angle` icons

### DIFF
--- a/demo/12px/index.js
+++ b/demo/12px/index.js
@@ -193,7 +193,6 @@ Garden.svgIDs = [
   'zd-svg-icon-12-overflow-stroke',
   'zd-svg-icon-12-panels-fill',
   'zd-svg-icon-12-panels-stroke',
-  'zd-svg-icon-12-paperclip-angle',
   'zd-svg-icon-12-paperclip',
   'zd-svg-icon-12-pause-fill',
   'zd-svg-icon-12-pause-stroke',

--- a/demo/16px/index.js
+++ b/demo/16px/index.js
@@ -193,7 +193,6 @@ Garden.svgIDs = [
   'zd-svg-icon-16-overflow-stroke',
   'zd-svg-icon-16-panels-fill',
   'zd-svg-icon-16-panels-stroke',
-  'zd-svg-icon-16-paperclip-angle',
   'zd-svg-icon-16-paperclip',
   'zd-svg-icon-16-pause-fill',
   'zd-svg-icon-16-pause-stroke',

--- a/demo/index.html
+++ b/demo/index.html
@@ -58,7 +58,7 @@
   <use xlink:href="index.svg#zd-svg-icon-26-zendesk">
 </svg>
 
-<svg class="u-fg-apple-green u-mega u-ml" fill="#555">
+<svg class="u-fg-support-green u-mega u-ml" fill="#555">
   <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support">
 </svg></textarea>
         </div>

--- a/src/12/paperclip-angle.svg
+++ b/src/12/paperclip-angle.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
-  <path fill="none" stroke="currentColor" stroke-linecap="round" d="M5 1.8L1.5 5.3C.2 6.6.2 8.7 1.5 9.9s3.4 1.3 4.6 0l4.6-4.6c.9-.9.9-2.2 0-3.1s-2.2-.9-3.1 0L3.1 6.8c-.4.4-.4 1.1 0 1.5s1.1.4 1.5 0l3.5-3.5"/>
-</svg>

--- a/src/16/paperclip-angle.svg
+++ b/src/16/paperclip-angle.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-  <path fill="none" stroke="currentColor" stroke-linecap="round" d="M11.3 6.3L6 11.6c-.7.7-1.7.7-2.4 0-.6-.7-.6-1.8.1-2.4l6.9-6.9c1.1-1.1 2.9-1.1 4 0s1.1 2.9 0 4l-7.1 7.1c-1.5 1.5-4 1.5-5.6 0-1.5-1.5-1.5-4 0-5.5l5.6-5.6"/>
-</svg>


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Pruning outdated designs that are not intended for use.

## Detail

Demo pages published for review:
https://garden.zendesk.com/svg-icons/12px/
https://garden.zendesk.com/svg-icons/16px/

## Checklist

* [x] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
