### PR TITLE
chore: replace deprecated `css-utilities` classes in demo

### DIFF
--- a/demo/26px/index.html
+++ b/demo/26px/index.html
@@ -118,61 +118,61 @@
     <div class="c-main__body">
       <div class="l-grid u-mb-lg">
       </div>
-      <h2 class="u-beta u-mb">Wordmarks</h2>
+      <h2 class="u-fs-lg u-mb">Wordmarks</h2>
       <div class="l-grid u-mb-lg">
         <span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-chat">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-chat">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-chat"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-chat"&gt;</code>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-connect">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-connect">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-connect"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-connect"&gt;</code>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-explore">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-explore">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-explore"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-explore"&gt;</code>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-guide">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-guide">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-guide"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-guide"&gt;</code>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-message">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-message">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-message"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-message"&gt;</code>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-support">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-support">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-support"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-support"&gt;</code>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-sell">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-sell">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-sell"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-sell"&gt;</code>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-talk">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-talk">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-talk"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-talk"&gt;</code>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
           <svg class="wordmark wordmark-zendesk">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-zendesk">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-zendesk"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-zendesk"&gt;</code>
         </span
         ><span class="l-grid__item u-2/2 u-mb u-truncate">
           <svg class="wordmark wordmark-capital-the">
@@ -184,21 +184,21 @@
           <svg class="wordmark wordmark-capital-suite">
             <use xlink:href="../index.svg#zd-svg-icon-26-wordmark-capital-suite">
           </svg>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-capital-the"&gt;</code>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-capital-zendesk"&gt;</code>
-          <code class="c-code u-micro u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-capital-suite"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-capital-the"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-capital-zendesk"&gt;</code>
+          <code class="c-code u-fs-xs u-p-xs">&lt;svg id="zd-svg-icon-26-wordmark-capital-suite"&gt;</code>
         </span>
       </div>
-      <h2 class="u-beta u-mb">Wordmark Layout</h2>
+      <h2 class="u-fs-lg u-mb">Wordmark Layout</h2>
       <p class="u-mb">The wordmarks shown below are positioned using
       size-relative margins that ensure the baseline of the word is aligned with
       the bottom of the logo. In addition, whitespace is added between the logo
       and the wordmark. Logos and wordmarks can be combined to produce a variety
       of layouts; however, it is critical that the end result adheres to
       published brand guidelines.</p>
-      <div class="l-grid u-fg-algae u-mb-lg">
+      <div class="l-grid u-fg-kale-700 u-mb-lg">
         <span class="l-grid__item u-1/2 u-mb u-truncate">
-          <svg class="relationshape u-fg-sea-buckthorn">
+          <svg class="relationshape u-fg-chat-orange">
             <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat">
           </svg>
           <svg class="wordmark wordmark-chat">
@@ -214,7 +214,7 @@
           </svg>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
-          <svg class="relationshape u-fg-flamingo">
+          <svg class="relationshape u-fg-connect-red">
             <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-connect">
           </svg>
           <svg class="wordmark wordmark-connect">
@@ -230,7 +230,7 @@
           </svg>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
-          <svg class="relationshape u-fg-pelorous">
+          <svg class="relationshape u-fg-explore-blue">
             <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-explore">
           </svg>
           <svg class="wordmark wordmark-explore">
@@ -246,7 +246,7 @@
           </svg>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
-          <svg class="relationshape u-fg-mandy">
+          <svg class="relationshape u-fg-guide-pink">
             <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide">
           </svg>
           <svg class="wordmark wordmark-guide">
@@ -262,7 +262,7 @@
           </svg>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
-          <svg class="relationshape u-fg-verdigris">
+          <svg class="relationshape u-fg-message-green">
             <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-message">
           </svg>
           <svg class="wordmark wordmark-message">
@@ -278,7 +278,7 @@
           </svg>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
-          <svg class="relationshape u-fg-apple-green">
+          <svg class="relationshape u-fg-support-green">
             <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support">
           </svg>
           <svg class="wordmark wordmark-support">
@@ -310,7 +310,7 @@
           </svg>
         </span
         ><span class="l-grid__item u-1/2 u-mb u-truncate">
-          <svg class="relationshape u-fg-golden-dream">
+          <svg class="relationshape u-fg-talk-yellow">
             <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk">
           </svg>
           <svg class="wordmark wordmark-talk">

--- a/demo/index.css
+++ b/demo/index.css
@@ -15,3 +15,5 @@ svg {
 .c-range--inline .c-range__input {
   width: 156px;
 }
+
+.u-fs-xs { font-size: 10px !important; }

--- a/demo/index.html
+++ b/demo/index.html
@@ -44,21 +44,21 @@
     <div class="c-main__body">
       <p class="u-mb">Garden SVG icons come in several different flavors.
       Follow the links below to check out the different icon sizes.</p>
-      <ul class="u-delta u-mb">
+      <ul class="u-fs-lg u-mb">
         <li class="u-mb-xs"><a href="12px">12 px</a></li>
         <li class="u-mb-xs"><a href="14px">14 px</a></li>
         <li class="u-mb-xs"><a href="16px">16 px</a></li>
         <li class="u-mb-xs"><a href="26px">26 px</a></li>
       </ul>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
-<textarea class="c-playground__code"><svg class="u-fg-inherit u-mega">
+<textarea class="c-playground__code"><svg class="u-fg-inherit u-fs-xxl">
   <use xlink:href="index.svg#zd-svg-icon-26-zendesk">
 </svg>
 
-<svg class="u-fg-support-green u-mega u-ml" fill="#555">
+<svg class="u-fg-support-green u-fs-xxl u-ml" fill="#555">
   <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support">
 </svg></textarea>
         </div>

--- a/demo/index.js
+++ b/demo/index.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
     if (value.indexOf('wordmark') === -1) {
       $('.c-main__body > .l-grid:first-child').append('<span class="l-grid__item u-1/4 u-mb u-truncate">' +
         '<svg><use xlink:href="../index.svg#' + value + '"></svg>\n' +
-        '<code class="c-code u-micro u-p-xs">&lt;svg id="' + value + '"&gt;</code>' +
+        '<code class="c-code u-fs-xs u-p-xs">&lt;svg id="' + value + '"&gt;</code>' +
       '</span>');
     }
   });


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Detail

https://github.com/zendeskgarden/css-components/pull/169

## Checklist

* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
