### PR TITLE
feat: add 26px `answer-bot` and `building` icons

### DIFF
--- a/demo/26px/index.html
+++ b/demo/26px/index.html
@@ -17,6 +17,11 @@
   <link href="../index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/css-components/utilities/index.css" rel="stylesheet">
   <style>
+  body:not(.is-dark) #zd-svg-icon-26-answer-bot {
+    fill: #616788;
+    color: #D0EEEC;
+  }
+
   .c-main svg { font-size: 26px; }
 
   .relationshape {

--- a/demo/26px/index.js
+++ b/demo/26px/index.js
@@ -1,8 +1,10 @@
 Garden.svgIDs = [
+  'zd-svg-icon-26-answer-bot',
   'zd-svg-icon-26-app',
   'zd-svg-icon-26-arrange-content',
   'zd-svg-icon-26-bar-chart',
   'zd-svg-icon-26-book',
+  'zd-svg-icon-26-building',
   'zd-svg-icon-26-call-in',
   'zd-svg-icon-26-chat',
   'zd-svg-icon-26-checkbox',

--- a/demo/index.js
+++ b/demo/index.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
   $.each(Garden.svgIDs, function(index, value) {
     if (value.indexOf('wordmark') === -1) {
       $('.c-main__body > .l-grid:first-child').append('<span class="l-grid__item u-1/4 u-mb u-truncate">' +
-        '<svg><use xlink:href="../index.svg#' + value + '"></svg>\n' +
+        '<svg id="' + value + '"><use xlink:href="../index.svg#' + value + '"></svg>\n' +
         '<code class="c-code u-fs-xs u-p-xs">&lt;svg id="' + value + '"&gt;</code>' +
       '</span>');
     }

--- a/src/26/answer-bot.svg
+++ b/src/26/answer-bot.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" focusable="false" viewBox="0 0 26 26">
+  <path fill="currentColor" d="M0 0h26v26H0z"/>
+  <circle cx="5.5" cy="12.5" r="1.5"/>
+  <circle cx="20.5" cy="12.5" r="1.5"/>
+</svg>

--- a/src/26/building.svg
+++ b/src/26/building.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" focusable="false" viewBox="0 0 26 26">
+  <path fill="currentColor" d="M5 4a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1h-3a1 1 0 0 1-1-1v-4a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4zm4 2v3h3V6H9zm0 5v3h3v-3H9zm5-5v3h3V6h-3zm0 5v3h3v-3h-3z"/>
+</svg>


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Detail

Demo prepublished for review: https://garden.zendesk.com/svg-icons/26px/

## Checklist

* [x] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
