### PR TITLE
fix: larger scale `sunshine` SVG to match relationshapes

### DIFF
--- a/src/26/sunshine.svg
+++ b/src/26/sunshine.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" focusable="false" viewBox="0 0 26 26">
-  <path fill="currentColor" d="M3.832 18A9.966 9.966 0 0 1 3 14C3 8.477 7.477 4 13 4s10 4.477 10 10a9.966 9.966 0 0 1-.832 4H3.832z"/>
+  <path fill="currentColor" d="M.996 20A12.96 12.96 0 0 1 0 15C0 7.82 5.82 2 13 2s13 5.82 13 13c0 1.772-.354 3.46-.996 5H.996z"/>
 </svg>


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Detail

Pre-published demo for review: https://garden.zendesk.com/svg-icons/26px/

## Checklist

* [x] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
