### PR TITLE
feat: add `shapes` icons

### DIFF
--- a/demo/12px/index.js
+++ b/demo/12px/index.js
@@ -258,6 +258,8 @@ Garden.svgIDs = [
   'zd-svg-icon-12-reload-stroke',
   'zd-svg-icon-12-search-fill',
   'zd-svg-icon-12-search-stroke',
+  'zd-svg-icon-12-shapes-fill',
+  'zd-svg-icon-12-shapes-stroke',
   'zd-svg-icon-12-share-fill',
   'zd-svg-icon-12-share-stroke',
   'zd-svg-icon-12-shield-fill',

--- a/demo/16px/index.js
+++ b/demo/16px/index.js
@@ -258,6 +258,8 @@ Garden.svgIDs = [
   'zd-svg-icon-16-reload-stroke',
   'zd-svg-icon-16-search-fill',
   'zd-svg-icon-16-search-stroke',
+  'zd-svg-icon-16-shapes-fill',
+  'zd-svg-icon-16-shapes-stroke',
   'zd-svg-icon-16-share-fill',
   'zd-svg-icon-16-share-stroke',
   'zd-svg-icon-16-shield-fill',

--- a/demo/26px/index.js
+++ b/demo/26px/index.js
@@ -48,6 +48,7 @@ Garden.svgIDs = [
   'zd-svg-icon-26-search',
   'zd-svg-icon-26-security',
   'zd-svg-icon-26-settings-fill',
+  'zd-svg-icon-26-shapes',
   'zd-svg-icon-26-sunshine',
   'zd-svg-icon-26-user-lock',
   'zd-svg-icon-26-views-fill',

--- a/src/12/shapes-fill.svg
+++ b/src/12/shapes-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
+  <path fill="currentColor" d="M0 8a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H1a1 1 0 01-1-1V8zm9.25-1.5a2.75 2.75 0 110 5.5 2.75 2.75 0 010-5.5zM6.832.445l2 3A1 1 0 018 5H4a1 1 0 01-.832-1.555l2-3a1 1 0 011.664 0z"/>
+</svg>

--- a/src/12/shapes-stroke.svg
+++ b/src/12/shapes-stroke.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
+  <path fill="currentColor" d="M4 7a1 1 0 011 1v3a1 1 0 01-1 1H1a1 1 0 01-1-1V8a1 1 0 011-1h3zm5.25-.5a2.75 2.75 0 110 5.5 2.75 2.75 0 010-5.5zM4 8H1v3h3V8zm5.25-.5a1.75 1.75 0 100 3.5 1.75 1.75 0 000-3.5zM6.832.445l2 3A1 1 0 018 5H4a1 1 0 01-.832-1.555l2-3a1 1 0 011.664 0zM6 1L4 4h4L6 1z"/>
+</svg>

--- a/src/16/shapes-fill.svg
+++ b/src/16/shapes-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M6 9a1 1 0 011 1v5a1 1 0 01-1 1H1a1 1 0 01-1-1v-5a1 1 0 011-1h5zm6.25-.5a3.75 3.75 0 110 7.5 3.75 3.75 0 010-7.5zM8.857.486l3 5A1 1 0 0111 7H5a1 1 0 01-.857-1.514l3-5a1 1 0 011.714 0z"/>
+</svg>

--- a/src/16/shapes-stroke.svg
+++ b/src/16/shapes-stroke.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M6 9a1 1 0 011 1v5a1 1 0 01-1 1H1a1 1 0 01-1-1v-5a1 1 0 011-1h5zm6.25-.5a3.75 3.75 0 110 7.5 3.75 3.75 0 010-7.5zM6 10H1v5h5v-5zm6.25-.5a2.75 2.75 0 100 5.5 2.75 2.75 0 000-5.5zM8.857.486l3 5A1 1 0 0111 7H5a1 1 0 01-.857-1.514l3-5a1 1 0 011.714 0zM8 1L5 6h6L8 1z"/>
+</svg>

--- a/src/26/shapes.svg
+++ b/src/26/shapes.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" focusable="false" viewBox="0 0 26 26">
+  <path fill="currentColor" d="M19.75 14a5.75 5.75 0 110 11.5 5.75 5.75 0 010-11.5zM10 15a1 1 0 011 1v8a1 1 0 01-1 1H2a1 1 0 01-1-1v-8a1 1 0 011-1h8zm3.934-13.49l5.063 9a1 1 0 01-.872 1.49H8a1 1 0 01-.872-1.49l5.063-9a1 1 0 011.743 0z"/>
+</svg>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat: add a new
     'widget' icon". the title informs the semantic version bump if this
     PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description
Adds the `shapes` icon in:

- 12px-fill
- 12px-stroke
- 16px-fill
- 16px-stroke
- 26px


![image](https://user-images.githubusercontent.com/29072694/66174690-32a1bd00-e60b-11e9-88e9-adf3a520b4b2.png)


<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [x] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
