### PR TITLE
fix: revise grid 2x2 icon

### DIFF
--- a/src/12/grid-2x2-stroke.svg
+++ b/src/12/grid-2x2-stroke.svg
@@ -1,8 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
-  <g fill="none" stroke="currentColor">
-    <rect width="4" height="4" x=".5" y=".5" rx=".5" ry=".5"/>
-    <rect width="4" height="4" x=".5" y="7.5" rx=".5" ry=".5"/>
-    <rect width="4" height="4" x="7.5" y=".5" rx=".5" ry=".5"/>
-    <rect width="4" height="4" x="7.5" y="7.5" rx=".5" ry=".5"/>
-  </g>
+  <path fill="currentColor" d="M1 1v3h3V1H1zm3 6a1 1 0 011 1v3a1 1 0 01-1 1H1a1 1 0 01-1-1V8a1 1 0 011-1h3zm7 0a1 1 0 011 1v3a1 1 0 01-1 1H8a1 1 0 01-1-1V8a1 1 0 011-1h3zM4 8H1v3h3V8zm7 0H8v3h3V8zM4 0a1 1 0 011 1v3a1 1 0 01-1 1H1a1 1 0 01-1-1V1a1 1 0 011-1h3zm7 0a1 1 0 011 1v3a1 1 0 01-1 1H8a1 1 0 01-1-1V1a1 1 0 011-1h3zm0 1H8v3h3V1z"/>
 </svg>

--- a/src/16/grid-2x2-stroke.svg
+++ b/src/16/grid-2x2-stroke.svg
@@ -1,8 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-  <g fill="none" stroke="currentColor">
-    <rect width="6" height="6" x=".5" y=".5" rx=".5" ry=".5"/>
-    <rect width="6" height="6" x=".5" y="9.5" rx=".5" ry=".5"/>
-    <rect width="6" height="6" x="9.5" y=".5" rx=".5" ry=".5"/>
-    <rect width="6" height="6" x="9.5" y="9.5" rx=".5" ry=".5"/>
-  </g>
+  <path fill="currentColor" d="M1 1v5h5V1H1zm5 8a1 1 0 011 1v5a1 1 0 01-1 1H1a1 1 0 01-1-1v-5a1 1 0 011-1h5zm9 0a1 1 0 011 1v5a1 1 0 01-1 1h-5a1 1 0 01-1-1v-5a1 1 0 011-1h5zm-9 1H1v5h5v-5zm9 0h-5v5h5v-5zM6 0a1 1 0 011 1v5a1 1 0 01-1 1H1a1 1 0 01-1-1V1a1 1 0 011-1h5zm9 0a1 1 0 011 1v5a1 1 0 01-1 1h-5a1 1 0 01-1-1V1a1 1 0 011-1h5zm0 1h-5v5h5V1z"/>
 </svg>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat: add a new
     'widget' icon". the title informs the semantic version bump if this
     PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Revised icons for:

- `12px/grid-2x2-stroke`
- `16px/grid-2x2-stroke`

Demo pre-published for review: https://garden.zendesk.com/svg-icons/16px/

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [ ] :black_medium_small_square: Renders as expected in "dark" mode
* [ ] :white_large_square: Renders as expected @ 2x scale
