### PR TITLE
feat: add `circle-sm` icons

### DIFF
--- a/demo/12px/index.js
+++ b/demo/12px/index.js
@@ -71,6 +71,8 @@ Garden.svgIDs = [
   'zd-svg-icon-12-chevron-up-stroke',
   'zd-svg-icon-12-circle-fill',
   'zd-svg-icon-12-circle-full-stroke',
+  'zd-svg-icon-12-circle-sm-fill',
+  'zd-svg-icon-12-circle-sm-stroke',
   'zd-svg-icon-12-circle-stroke',
   'zd-svg-icon-12-clipboard-blank-fill',
   'zd-svg-icon-12-clipboard-blank-stroke',

--- a/demo/16px/index.js
+++ b/demo/16px/index.js
@@ -71,6 +71,8 @@ Garden.svgIDs = [
   'zd-svg-icon-16-chevron-up-stroke',
   'zd-svg-icon-16-circle-fill',
   'zd-svg-icon-16-circle-full-stroke',
+  'zd-svg-icon-16-circle-sm-fill',
+  'zd-svg-icon-16-circle-sm-stroke',
   'zd-svg-icon-16-circle-stroke',
   'zd-svg-icon-16-clipboard-blank-fill',
   'zd-svg-icon-16-clipboard-blank-stroke',

--- a/src/12/circle-sm-fill.svg
+++ b/src/12/circle-sm-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
+  <circle cx="6" cy="6" r="2" fill="currentColor"/>
+</svg>

--- a/src/12/circle-sm-stroke.svg
+++ b/src/12/circle-sm-stroke.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
+  <circle cx="6" cy="6" r="2.5" fill="none" stroke="currentColor"/>
+</svg>

--- a/src/16/circle-sm-fill.svg
+++ b/src/16/circle-sm-fill.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="6" fill="currentColor"/>
+</svg>
+

--- a/src/16/circle-sm-fill.svg
+++ b/src/16/circle-sm-fill.svg
@@ -1,4 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
   <circle cx="8" cy="8" r="6" fill="currentColor"/>
 </svg>
-

--- a/src/16/circle-sm-stroke.svg
+++ b/src/16/circle-sm-stroke.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="6.5" fill="none" stroke="currentColor"/>
+</svg>
+

--- a/src/16/circle-sm-stroke.svg
+++ b/src/16/circle-sm-stroke.svg
@@ -1,4 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
   <circle cx="8" cy="8" r="6.5" fill="none" stroke="currentColor"/>
 </svg>
-


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This PR fills in dimensions for small `fill` circle icons used by `react-components` [Radio](https://garden.zendesk.com/react-components/forms/#radio) (12px) and [Toggle](https://garden.zendesk.com/react-components/forms/#toggle) (16px). The `stroke` versions are added for completeness.

## Detail

Demo pre-published for review at https://garden.zendesk.com/svg-icons/.

## Checklist

* [x] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
