### PR TITLE
feat: fix 26px book icon

### DIFF
--- a/src/26/book.svg
+++ b/src/26/book.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" focusable="false" viewBox="0 0 26 26">
-  <path fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="2" d="M4 4.5v16.99A2.503 2.503 0 006.508 24H20c.552 0 1-.455 1-1V8c0-.552-.455-1-1-1H6.508A2.498 2.498 0 014 4.5C4 3.12 5.125 2 6.5 2H19c.552 0 1 .444 1 1v4M9 16h8m-8-4h8"/>
+  <path fill="currentColor" d="M19 1c1.105 0 2 .892 2 2v3.27c.596.346 1 .992 1 1.73v15c0 1.099-.897 2-2 2H6.51A3.503 3.503 0 013 21.49V4.506A3.505 3.505 0 016.5 1H19zM5 7.663v13.83A1.503 1.503 0 006.508 23H20V8H6.512A3.498 3.498 0 015 7.663zM16 15a1 1 0 010 2h-6a1 1 0 110-2h6zm0-4a1 1 0 110 2h-6a1 1 0 010-2h6zm3-8H6.5a1.5 1.5 0 10.008 3H19V3z"/>
 </svg>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat: add a new
     'widget' icon". the title informs the semantic version bump if this
     PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Use rounded strokes for the text on the cover of `26/book` icon to be consistent with our icon style.

## Detail

See deployment link for review.

## Checklist

* [ ] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
