### PR TITLE
fix: adjust answer-bot brand colors

### DIFF
--- a/demo/26px/index.html
+++ b/demo/26px/index.html
@@ -18,8 +18,8 @@
   <link href="//zendeskgarden.github.io/css-components/utilities/index.css" rel="stylesheet">
   <style>
   body:not(.is-dark) #zd-svg-icon-26-answer-bot {
-    fill: #616788;
-    color: #D0EEEC;
+    fill: #03363D;
+    color: #D6EEF1;
   }
 
   .c-main svg { font-size: 26px; }


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Checklist

* [x] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
