### PR TITLE
fix: adjust bold icons to better match typography

### DIFF
--- a/src/12/bold-fill.svg
+++ b/src/12/bold-fill.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
-  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M3 1v10M3 1h3.4C7.8 1 9 2.1 9 3.5S7.8 6 6.4 6H3m0 0h3.4C7.8 6 9 7.1 9 8.5S7.8 11 6.4 11H3"/>
+  <path fill="currentColor" d="M5.9 0c1.96 0 3.6 1.554 3.6 3.5a3.42 3.42 0 01-.86 2.265A3.453 3.453 0 0110 8.5c0 1.946-1.64 3.5-3.6 3.5H3a1 1 0 01-1-1V1a1 1 0 011-1h2.9zM4 10h2.4C7.279 10 8 9.317 8 8.5S7.279 7 6.4 7H4v3zm1.9-8H4v3h1.9c.879 0 1.6-.683 1.6-1.5S6.779 2 5.9 2z"/>
 </svg>

--- a/src/12/bold-stroke.svg
+++ b/src/12/bold-stroke.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
-  <path fill="none" stroke="currentColor" stroke-linecap="round" d="M2.5 1.5v10m0-10h3.4c1.4 0 2.6 1.1 2.6 2.5S7.3 6.5 5.9 6.5H2.5m0 0h3.4c1.4 0 2.6 1.1 2.6 2.5s-1.2 2.5-2.6 2.5H2.5"/>
+  <path fill="currentColor" d="M5.4 1c1.69 0 3.1 1.336 3.1 3 0 .95-.46 1.794-1.17 2.342C8.317 6.842 9 7.842 9 9c0 1.664-1.41 3-3.1 3H2.5a.5.5 0 01-.5-.5v-10a.5.5 0 01.5-.5h2.9zM3 11h2.9C7.05 11 8 10.1 8 9s-.95-2-2.1-2H3v4zm2.4-9H3v4h2.4c1.15 0 2.1-.9 2.1-2s-.95-2-2.1-2z"/>
 </svg>

--- a/src/16/bold-fill.svg
+++ b/src/16/bold-fill.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 1v14M4 1h4.5C10.4 1 12 2.6 12 4.5S10.4 8 8.5 8H4m0 0h4.5c1.9 0 3.5 1.6 3.5 3.5S10.4 15 8.5 15H4"/>
+  <path fill="currentColor" d="M7.5 0C9.952 0 12 2.048 12 4.5a4.483 4.483 0 01-1.27 3.108C12.078 8.39 13 9.855 13 11.5c0 2.452-2.048 4.5-4.5 4.5H4a1 1 0 01-1-1V1a1 1 0 011-1h3.5zM5 14h3.5c1.348 0 2.5-1.152 2.5-2.5S9.848 9 8.5 9H5v5zM7.5 2H5v5h2.5C8.848 7 10 5.848 10 4.5S8.848 2 7.5 2z"/>
 </svg>

--- a/src/16/bold-stroke.svg
+++ b/src/16/bold-stroke.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-  <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3.5 1.5v14m0-14H8c1.9 0 3.5 1.6 3.5 3.5S9.9 8.5 8 8.5H3.5m0 0H8c1.9 0 3.5 1.6 3.5 3.5S9.9 15.5 8 15.5H3.5"/>
+  <path fill="currentColor" d="M7 1c2.176 0 4 1.824 4 4 0 1.315-.666 2.501-1.673 3.234C10.869 8.792 12 10.287 12 12c0 2.176-1.824 4-4 4H3.5a.5.5 0 01-.5-.5v-14a.5.5 0 01.5-.5H7zM4 15h4c1.624 0 3-1.376 3-3S9.624 9 8 9H4v6zM7 2H4v6h3c1.624 0 3-1.376 3-3S8.624 2 7 2z"/>
 </svg>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat: add a new
     'widget' icon". the title informs the semantic version bump if this
     PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adjust the bold icons to be more typographically correct

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

See deployment for review

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
