### PR TITLE
feat: add align-justify icons

### DIFF
--- a/demo/12px/index.js
+++ b/demo/12px/index.js
@@ -7,6 +7,8 @@ Garden.svgIDs = [
   'zd-svg-icon-12-alert-warning-stroke',
   'zd-svg-icon-12-align-center-fill',
   'zd-svg-icon-12-align-center-stroke',
+  'zd-svg-icon-12-align-justify-fill',
+  'zd-svg-icon-12-align-justify-stroke',
   'zd-svg-icon-12-align-left-fill',
   'zd-svg-icon-12-align-left-stroke',
   'zd-svg-icon-12-align-right-fill',

--- a/demo/16px/index.js
+++ b/demo/16px/index.js
@@ -7,6 +7,8 @@ Garden.svgIDs = [
   'zd-svg-icon-16-alert-warning-stroke',
   'zd-svg-icon-16-align-center-fill',
   'zd-svg-icon-16-align-center-stroke',
+  'zd-svg-icon-16-align-justify-fill',
+  'zd-svg-icon-16-align-justify-stroke',
   'zd-svg-icon-16-align-left-fill',
   'zd-svg-icon-16-align-left-stroke',
   'zd-svg-icon-16-align-right-fill',

--- a/src/12/align-justify-fill.svg
+++ b/src/12/align-justify-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
+  <path fill="currentColor" d="M2 11a1 1 0 010-2h8a1 1 0 010 2H2zm0-3a1 1 0 110-2h8a1 1 0 010 2H2zm0-3a1 1 0 110-2h8a1 1 0 010 2H2zm0-3a1 1 0 110-2h8a1 1 0 010 2H2z"/>
+</svg>

--- a/src/12/align-justify-stroke.svg
+++ b/src/12/align-justify-stroke.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12">
+  <path fill="currentColor" d="M1.5 11a.5.5 0 110-1h9a.5.5 0 110 1h-9zm0-3a.5.5 0 010-1h9a.5.5 0 110 1h-9zm0-3a.5.5 0 010-1h9a.5.5 0 110 1h-9zm0-3a.5.5 0 010-1h9a.5.5 0 110 1h-9z"/>
+</svg>

--- a/src/16/align-justify-fill.svg
+++ b/src/16/align-justify-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M2 15a1 1 0 010-2h12a1 1 0 010 2H2zm0-4a1 1 0 010-2h12a1 1 0 010 2H2zm0-4a1 1 0 110-2h12a1 1 0 010 2H2zm0-4a1 1 0 110-2h12a1 1 0 010 2H2z"/>
+</svg>

--- a/src/16/align-justify-stroke.svg
+++ b/src/16/align-justify-stroke.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M1.5 10a.5.5 0 010-1h13a.5.5 0 110 1h-13zm0-8a.5.5 0 010-1h13a.5.5 0 110 1h-13zm0 4a.5.5 0 010-1h13a.5.5 0 110 1h-13zm0 8a.5.5 0 110-1h13a.5.5 0 110 1h-13z"/>
+</svg>


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "feat: add a new
     'widget' icon". the title informs the semantic version bump if this
     PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds new icons:

- 12/align-justify-fill
- 12/align-justify-stroke
- 16/align-justify-fill
- 16/align-justify-stroke


## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: SVG updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: SVG demo is up-to-date (`yarn start`)
* [x] :black_medium_small_square: Renders as expected in "dark" mode
* [x] :white_large_square: Renders as expected @ 2x scale
